### PR TITLE
Correct the target

### DIFF
--- a/src/com/CMakeLists.txt
+++ b/src/com/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(plug-communication-usb
     UsbException.cpp
     UsbDevice.cpp
     )
-target_link_libraries(plug-communication PRIVATE libusb-1.0::libusb-1.0)
+target_link_libraries(plug-communication-usb PRIVATE libusb-1.0::libusb-1.0)
 
 add_library(plug-libusb LibUsbCompat.cpp)
 target_link_libraries(plug-libusb PUBLIC libusb-1.0::libusb-1.0)


### PR DESCRIPTION
`plug-communication-usb` requires libusb-1.0, not `plug-communication`. (#9)