### PR TITLE
Fix CMake default install paths

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -1,5 +1,5 @@
-set(PLUG_UDEV_RULE_PATH "/lib/udev/rules.d" CACHE PATH "Udev rules directory.")
-set(PLUG_DESKTOP_PATH "/lib/share/applications" CACHE PATH "Desktop file directory.")
+set(PLUG_UDEV_RULE_PATH "/usr/lib/udev/rules.d" CACHE PATH "Udev rules directory.")
+set(PLUG_DESKTOP_PATH "/usr/share/applications" CACHE PATH "Desktop file directory.")
 set(PLUG_ICON_PATH "/usr/share/icons/hicolor" CACHE PATH "HiColor icon theme directory.")
 
 install(FILES


### PR DESCRIPTION
Hello,

I made the CMake default install paths a bit more conforming to the Freedesktop standards (source for [udev](https://www.freedesktop.org/software/systemd/man/udev.html), [desktop files](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html)).