### PR TITLE
Adding VID/PID for Mustang LT 40S

### DIFF
--- a/doc/USB.md
+++ b/doc/USB.md
@@ -24,4 +24,5 @@
 | Device         | VID  | PID  | Note |
 |----------------|:----:|:----:|------|
 | Mustang LT 25  | 1ed8 | 0037 |      |
+| Mustang LT 40S | 1ed8 | 0046 |      |
 | Rumble LT 25   | 1ed8 | 0038 |      |


### PR DESCRIPTION
I own this model, and I've discovered the PID/VID for it.  I realize this isn't a particularly major contribution, but I'm putting it out there as a means of opening communication, because I'm interested in reverse engineering in general, and in getting support for my own amp integrated in particular.

I've also done some Wireshark captures for the model, and will shortly invite you (https://github.com/offa) to have access to my (presently private) github repo where the captures are shared.  I'm more than happy for you to copy, publish and use these with or without attribution to myself.

I'm nervous about damaging my amp, so I'm planning to see whether the knowledge I get can be integrated into piorekf's upstream codebase rather than yours in the first instance.  My logic for trusting piorekf's codebase (slightly) more is that it is present in Debian and Ubuntu, probabily has a wider install base and I'd hope we'd have heard by now if anyone had mucked about with it and damaged their amp, but I'm still grateful for your update and completely open to experimenting with it at some later date.

Anyway, thanks again and best wishes with the project.
