### PR TITLE
Use /usr/lib/udev for udev rules

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -2,7 +2,7 @@ install(FILES
         ${CMAKE_SOURCE_DIR}/cmake/50-mustang.rules
         ${CMAKE_SOURCE_DIR}/cmake/70-mustang-uaccess.rules
         ${CMAKE_SOURCE_DIR}/cmake/70-mustang-plugdev.rules
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d
         )
 install(FILES ${CMAKE_SOURCE_DIR}/cmake/plug.desktop
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications


### PR DESCRIPTION
%{CMAKE_INSTALL_LIBDIR} translates to /usr/lib64 on 64-bit systems while udev always expects /usr/lib.

Fixes: #22 